### PR TITLE
Upgraded gradle and other libraries, using default flavor dimensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
-*/.idea
 .idea
-gen/
-.DS_Store
-Pods/
-Podfile.lock
-xcuserdata/
-*.xcworkspace/
-GoogleService-Info.plist
-npm-debug.log
+.gradle
+*.iml
+build
+local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,13 +17,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.2'
 
     defaultConfig {
         applicationId "com.google.firebase.samples.apps.friendlypix"
         minSdkVersion 17
-        targetSdkVersion 23
+        targetSdkVersion 27
         versionCode 3
         versionName "20160401.02"
     }
@@ -69,24 +69,24 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
 
-    compile 'com.firebaseui:firebase-ui-database:0.4.0'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:cardview-v7:23.4.0'
-    compile 'com.android.support:recyclerview-v7:23.4.0'
-    compile 'com.android.support:support-v4:23.4.0'
-    compile 'com.android.support:design:23.4.0'
-    compile 'com.android.support:percent:23.4.0'
-    compile 'com.google.android.gms:play-services-auth:9.0.2'
-    compile 'com.google.android.gms:play-services-location:9.0.2'
-    compile 'com.google.firebase:firebase-storage:9.0.2'
-    compile 'com.google.firebase:firebase-common:9.0.2'
-    compile 'com.google.firebase:firebase-auth:9.0.2'
-    compile 'com.google.firebase:firebase-database:9.0.2'
-    compile 'com.google.firebase:firebase-crash:9.0.2'
+    compile 'com.firebaseui:firebase-ui-database:1.2.0'
+    compile 'com.android.support:appcompat-v7:27.0.2'
+    compile 'com.android.support:cardview-v7:27.0.2'
+    compile 'com.android.support:recyclerview-v7:27.0.2'
+    compile 'com.android.support:support-v4:27.0.2'
+    compile 'com.android.support:design:27.0.2'
+    compile 'com.android.support:percent:27.0.2'
+    compile 'com.google.android.gms:play-services-auth:11.8.0'
+    compile 'com.google.android.gms:play-services-location:11.8.0'
+    compile 'com.google.firebase:firebase-storage:11.8.0'
+    compile 'com.google.firebase:firebase-common:11.8.0'
+    compile 'com.google.firebase:firebase-auth:11.8.0'
+    compile 'com.google.firebase:firebase-database:11.8.0'
+    compile 'com.google.firebase:firebase-crash:11.8.0'
     compile 'pub.devrel:easypermissions:0.1.5'
-    compile 'com.github.bumptech.glide:glide:3.6.0'
-    compile 'de.hdodenhof:circleimageview:2.0.0'
-    compile 'org.apache.httpcomponents:httpcore:4.3.1'
+    compile 'com.github.bumptech.glide:glide:4.5.0'
+    compile 'de.hdodenhof:circleimageview:2.1.0'
+    compile 'org.apache.httpcomponents:httpcore:4.4.1'
     compile 'org.apache.httpcomponents:httpmime:4.3.1'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.3'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,8 @@ android {
             signingConfig signingConfigs.release
         }
     }
+
+    flavorDimensions "default"
     productFlavors {
         dev {
         }

--- a/app/src/main/java/com/google/firebase/samples/apps/friendlypix/GlideUtil.java
+++ b/app/src/main/java/com/google/firebase/samples/apps/friendlypix/GlideUtil.java
@@ -21,6 +21,9 @@ import android.graphics.drawable.ColorDrawable;
 import android.support.v4.content.ContextCompat;
 import android.widget.ImageView;
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.RequestOptions;
+
+import static com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade;
 
 public class GlideUtil {
     public static void loadImage(String url, ImageView imageView) {
@@ -28,9 +31,10 @@ public class GlideUtil {
         ColorDrawable cd = new ColorDrawable(ContextCompat.getColor(context, R.color.blue_grey_500));
         Glide.with(context)
                 .load(url)
-                .placeholder(cd)
-                .crossFade()
-                .centerCrop()
+                .apply(new RequestOptions()
+                    .placeholder(cd)
+                    .centerCrop())
+                .transition(withCrossFade())
                 .into(imageView);
     }
 
@@ -38,9 +42,10 @@ public class GlideUtil {
         Context context = imageView.getContext();
         Glide.with(context)
                 .load(url)
-                .placeholder(R.drawable.ic_person_outline_black_24dp)
-                .dontAnimate()
-                .fitCenter()
+                .apply(new RequestOptions()
+                    .placeholder(R.drawable.ic_person_outline_black_24dp)
+                    .dontAnimate()
+                    .fitCenter())
                 .into(imageView);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,10 @@ buildscript {
     repositories {
         mavenLocal()
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.google.gms:google-services:3.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -17,6 +18,7 @@ allprojects {
     repositories {
         mavenLocal()
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 11:34:03 PDT 2015
+#Sat Feb 10 19:34:17 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
1. fixes several compilation issues with latest Android Studio and Support libraries. including #28 
2. Using .gitignore which is relevant to Android Studio instead of XCode
3. Upgraded glide to 4.5
4. Upgraded gradle version, support libraries, and firebase dependancies