### PR TITLE
Added cloud functions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Have a look at the [Web](web), [Android](android) or [iOS](ios) app for more det
 Visit [friendly-pix.com](https://friendly-pix.com) to try a hosted instance of the web app.
 
 
-## Cloud Functions
+## Requirements
 
-The required Cloud Functions can be found at [FriendlyPix Web Repository](https://github.com/firebase/friendlypix-web/tree/master/functions).
+The mobile FriendlyPix app need the Cloud Functions, the Realtime Database rules and the Cloud Storage rules to be deployed to work properly. You can find instructions at [FriendlyPix Web Repository](https://github.com/firebase/friendlypix-web/blob/master/README.md#mobile-apps).
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Have a look at the [Web](web), [Android](android) or [iOS](ios) app for more det
 Visit [friendly-pix.com](https://friendly-pix.com) to try a hosted instance of the web app.
 
 
+## Cloud Functions
+
+The required Cloud Functions can be found at [FriendlyPix Web Repository](https://github.com/firebase/friendlypix-web/tree/master/functions).
+
+
 ## Contributing
 
 We'd love that you contribute to the project. Before doing so please read our [Contributor guide](CONTRIBUTING.md).


### PR DESCRIPTION
There is no documentation pointing to the required Cloud Functions at all.

Developers trying to run mobile examples only (android and/or iOS) won't be able to make it work as expected.

Also, even on the web example, there is no instruction regarding publishing the functions.

This PR adds a link to the Cloud Functions into the README.